### PR TITLE
fix: Handle null/undefined values in Scatterplot Tooltip 

### DIFF
--- a/src/components/graph/Scatterplot/Tooltip.tsx
+++ b/src/components/graph/Scatterplot/Tooltip.tsx
@@ -33,9 +33,8 @@ export const Tooltip = ({ interactionData, boundsHeight }: TooltipProps) => {
             <b>{key}</b>
             <span>: </span>
             <span>
-            {
-              typeof val === "number" ? convertNumberNotation(val as number) : val.toString() as string
-            }</span>
+            {(val === undefined ||  val === null) ? "N/A" : typeof val === "number" ? convertNumberNotation(val as number) : val.toString()}
+            </span>
           </div>
         )
       })}


### PR DESCRIPTION
### Bug
- Hovering over a point with undefined/null values errors out

### Fix 
- Explicit checking for null/undefined