### PR TITLE
fix: Sort lineplot by datetime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=0.7.1
+VERSION=0.7.2
 .PHONY: build
 
 build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "visprex",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "visprex",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@heroicons/react": "^2.1.1",
         "@react-spring/web": "^9.7.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "visprex",
   "private": true,
-  "version": "0.7.1",
+  "version": "0.7.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/graph/Lineplot/Lineplot.tsx
+++ b/src/components/graph/Lineplot/Lineplot.tsx
@@ -51,7 +51,7 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
         d.x.getTime() >= xDomain[0].getTime() &&
         d.x.getTime() <= xDomain[1].getTime() &&
         typeof d.y === 'number'
-      );
+      ).sort((p1, p2) => p1.x.getTime() - p2.x.getTime());
 
       const xScale = d3.scaleTime()
         .domain(xDomain)


### PR DESCRIPTION
If the timestamp values are not sorted from lowest to highest in ascending order, it breaks the tooltip. This PR fixes this by sorting the matrix by timestamp for line plots.