### PR TITLE
chore: remove Makefile with deprecated container registry location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,0 @@
-VERSION=0.7.3
-.PHONY: build
-
-build:
-	gcloud config set project visprex && gcloud builds submit --tag eu.gcr.io/visprex/visprex:$(VERSION)


### PR DESCRIPTION
This is now migrated to Artifact Registry and images are pushed via GitHub Actions