### PR TITLE
build: Optimise d3 imports and remove lodash dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist-ssr
 *.sw?
 
 playground/
+bundle-report.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "postcss": "^8.4.32",
+        "rollup-plugin-visualizer": "^5.14.0",
         "tailwindcss": "^3.4.0",
         "typescript": "^5.2.2",
         "vite": "^6.2.1",
@@ -2597,6 +2598,57 @@
         "node": ">=8"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3134,6 +3186,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz",
+      "integrity": "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/define-properties": {
@@ -4048,6 +4109,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -4547,6 +4617,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -4790,6 +4875,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -5306,6 +5403,23 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/open/-/open-8.4.2.tgz",
+      "integrity": "sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==",
+      "dev": true,
+      "dependencies": {
+        "define-lazy-prop": "^2.0.0",
+        "is-docker": "^2.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -5857,6 +5971,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -5953,6 +6076,48 @@
         "@rollup/rollup-win32-ia32-msvc": "4.35.0",
         "@rollup/rollup-win32-x64-msvc": "4.35.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-5.14.0.tgz",
+      "integrity": "sha512-VlDXneTDaKsHIw8yzJAFWtrzguoJ/LnQ+lMpoVfYJ3jJF4Ihe5oYLAqLklIK/35lgUY+1yEzCkHyZ1j4A5w5fA==",
+      "dev": true,
+      "dependencies": {
+        "open": "^8.4.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^17.5.1"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/run-parallel": {
@@ -6224,6 +6389,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/source-map-js": {
@@ -7275,6 +7449,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
@@ -7285,6 +7468,53 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "d3": "^7.8.5",
     "dayjs": "^1.11.13",
     "heroicons": "^2.1.1",
-    "lodash": "^4.17.21",
     "papaparse": "^5.4.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
@@ -24,7 +23,6 @@
   "devDependencies": {
     "@types/d3": "^7.4.3",
     "@types/jest": "^29.5.14",
-    "@types/lodash": "^4.14.202",
     "@types/papaparse": "^5.3.14",
     "@types/react": "^18.2.43",
     "@types/react-dom": "^18.2.17",
@@ -39,6 +37,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "postcss": "^8.4.32",
+    "rollup-plugin-visualizer": "^5.14.0",
     "tailwindcss": "^3.4.0",
     "typescript": "^5.2.2",
     "vite": "^6.2.1",

--- a/src/components/graph/CorrelationMatrix/Renderer.tsx
+++ b/src/components/graph/CorrelationMatrix/Renderer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import * as d3 from "d3";
+import { scaleBand, scaleLinear } from "d3";
 import { InteractionData } from "./CorrelationMatrix";
 
 type RendererProps = {
@@ -25,22 +25,20 @@ export const Renderer = ({
   const domain = Array.from(new Set(data.map(function(d) { return d.x })))
 
   const xScale = useMemo(() => {
-    return d3
-      .scaleBand()
+    return scaleBand()
       .range([0, boundsWidth])
       .domain(allXGroups)
       .padding(0.01);
   }, [allXGroups, boundsWidth]);
 
   const yScale = useMemo(() => {
-    return d3
-      .scaleBand()
+    return scaleBand()
       .range([0, boundsHeight])
       .domain(allYGroups)
       .padding(0.01);
   }, [allYGroups, boundsHeight]);
 
-const colorScale = d3.scaleLinear<string>()
+const colorScale = scaleLinear<string>()
     .domain([-1, 0, 1])
     .range(["#B22222", "#fff", "#000080"]);
 

--- a/src/components/graph/CorrelationMatrix/Renderer.tsx
+++ b/src/components/graph/CorrelationMatrix/Renderer.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { scaleBand, scaleLinear } from "d3";
+import { scaleBand, scaleLinear } from "d3-scale";
 import { InteractionData } from "./CorrelationMatrix";
 
 type RendererProps = {

--- a/src/components/graph/Histogram/Renderer.tsx
+++ b/src/components/graph/Histogram/Renderer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef } from "react";
-import * as d3 from "d3";
+import { scaleBand, scaleLinear, bin, select, axisBottom, axisLeft } from "d3";
 import { Rectangle } from "./Rectangle";
 import { DataType } from "@/schema";
 
@@ -22,17 +22,16 @@ export const Renderer = ({ width, height, domain, data, dataType }: RendererProp
   
   const xLabelScale = useMemo(() => {
     if (dataType === DataType.Number) {
-      return d3.scaleBand()
+      return scaleBand()
     }
-    return d3
-      .scaleBand()
+    return scaleBand()
       .range([0, boundsWidth])
       .domain(Object.keys(data))
       .padding(0.2);
   }, [data, boundsWidth, dataType]);
 
   const xScale = useMemo(() => {
-    return d3.scaleLinear().domain(domain).range([10, boundsWidth]);
+    return scaleLinear().domain(domain).range([10, boundsWidth]);
   }, [domain, boundsWidth]);
 
   const buckets = useMemo(() => (
@@ -44,8 +43,7 @@ export const Renderer = ({ width, height, domain, data, dataType }: RendererProp
             length: value
         } as d3.Bin<number, number>))
     :
-      d3
-        .bin()
+        bin()
         .value((d) => d)
         .domain(domain)
         .thresholds(xScale.ticks(BUCKET_NUMBER))(data as number[])
@@ -56,15 +54,15 @@ export const Renderer = ({ width, height, domain, data, dataType }: RendererProp
     [DataType.Categorical, DataType.DateTime].includes(dataType) ?
       max = Math.max(...Object.values(data)) :
       max = Math.max(...buckets.map((bucket) => bucket?.length))
-    return d3.scaleLinear().range([boundsHeight, 0]).domain([0, max]).nice();
+    return scaleLinear().range([boundsHeight, 0]).domain([0, max]).nice();
   }, [dataType, data, buckets, boundsHeight]);
 
   useEffect(() => {
-    const svg = d3.select(histRef.current);
+    const svg = select(histRef.current);
     svg.selectAll("*").remove();
 
     const xAxisGenerator = [DataType.Categorical, DataType.DateTime].includes(dataType) ?
-      d3.axisBottom(xLabelScale) : d3.axisBottom(xScale);
+      axisBottom(xLabelScale) : axisBottom(xScale);
     svg
       .append("g")
       .attr("transform", "translate(0," + boundsHeight + ")")
@@ -78,7 +76,7 @@ export const Renderer = ({ width, height, domain, data, dataType }: RendererProp
         .attr("transform", "rotate(-20)")
         .attr("font-size", "9px")
     }
-    const yAxisGenerator = d3.axisLeft(yScale);
+    const yAxisGenerator = axisLeft(yScale);
     svg
       .append("g")
       .call(yAxisGenerator);

--- a/src/components/graph/Histogram/Renderer.tsx
+++ b/src/components/graph/Histogram/Renderer.tsx
@@ -1,5 +1,9 @@
 import { useEffect, useMemo, useRef } from "react";
-import { scaleBand, scaleLinear, bin, select, axisBottom, axisLeft } from "d3";
+import { scaleBand, scaleLinear } from "d3-scale";
+import { bin } from "d3-array";
+import { select } from "d3-selection";
+import { axisBottom, axisLeft } from "d3-axis";
+
 import { Rectangle } from "./Rectangle";
 import { DataType } from "@/schema";
 

--- a/src/components/graph/Lineplot/Lineplot.tsx
+++ b/src/components/graph/Lineplot/Lineplot.tsx
@@ -1,10 +1,14 @@
 import { useRef, useState, useEffect } from 'react';
-import { scaleTime, scaleLinear, line, select, pointer, bisector, axisBottom, axisLeft, curveMonotoneX } from "d3";
-
+import { scaleTime, scaleLinear } from "d3-scale";
+import { select } from "d3-selection";
+import { axisBottom, axisLeft } from "d3-axis";
+import { bisector } from "d3-array";
+import { line } from "d3-shape";
+import { pointer } from "d3-selection";
+import { curveMonotoneX } from "d3-shape";
 import { Schema, NumberSchema, DateTimeSchema, DataType, Value } from "@/schema";
 import { Tooltip, InteractionData } from './Tooltip';
 import { DateTimeRangeSelector } from '@/components/query';
-import _ from 'lodash';
 
 interface LineplotProps {
   width: number;
@@ -58,7 +62,7 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
         .domain(xDomain)
         .range([0, boundsWidth]);
 
-      const yDomain = [_.min(data.map(d => d.y)), _.max(data.map(d => d.y))] as [number, number];
+      const yDomain = [Math.min(...data.map(d => d.y)), Math.max(...data.map(d => d.y))] as [number, number];
 
       const yScale = scaleLinear()
         .domain(yDomain)

--- a/src/components/graph/Lineplot/Lineplot.tsx
+++ b/src/components/graph/Lineplot/Lineplot.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState, useEffect } from 'react';
-import * as d3 from 'd3';
+import { scaleTime, scaleLinear, line, select, pointer, bisector, axisBottom, axisLeft, curveMonotoneX } from "d3";
+
 import { Schema, NumberSchema, DateTimeSchema, DataType, Value } from "@/schema";
 import { Tooltip, InteractionData } from './Tooltip';
 import { DateTimeRangeSelector } from '@/components/query';
@@ -53,24 +54,24 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
         typeof d.y === 'number'
       ).sort((p1, p2) => p1.x.getTime() - p2.x.getTime());
 
-      const xScale = d3.scaleTime()
+      const xScale = scaleTime()
         .domain(xDomain)
         .range([0, boundsWidth]);
 
       const yDomain = [_.min(data.map(d => d.y)), _.max(data.map(d => d.y))] as [number, number];
 
-      const yScale = d3.scaleLinear()
+      const yScale = scaleLinear()
         .domain(yDomain)
         .range([boundsHeight, 0]);
 
-      const svg = d3.select(lineRef.current);
+      const svg = select(lineRef.current);
       svg.selectAll('*').remove();
   
       const plot = svg.append('g')
         .attr('transform', `translate(${margin.left},${margin.top})`);
   
-      const xAxis = d3.axisBottom(xScale);
-      const yAxis = d3.axisLeft(yScale);
+      const xAxis = axisBottom(xScale);
+      const yAxis = axisLeft(yScale);
   
       plot.append('g')
         .attr('class', 'x-axis')
@@ -81,10 +82,10 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
         .attr('class', 'y-axis')
         .call(yAxis);
   
-      const lineGenerator = d3.line<{ x: Date; y: number }>()
+      const lineGenerator = line<{ x: Date; y: number }>()
         .x(d => xScale(d.x))
         .y(d => yScale(d.y))
-        .curve(d3.curveMonotoneX);
+        .curve(curveMonotoneX);
 
       plot.append('path')
         .datum(data)
@@ -93,7 +94,7 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
         .attr('stroke-width', 2)
         .attr('d', lineGenerator);
   
-      const bisect = d3.bisector((d: { x: Date }) => d.x).left;
+      const bisect = bisector((d: { x: Date }) => d.x).left;
   
       const interactionLayer = plot.append('rect')
         .attr('width', boundsWidth)
@@ -111,7 +112,7 @@ export const Lineplot = ({ width, height, matrix, schema, keys }: LineplotProps)
   
       interactionLayer
         .on('mousemove', (event: MouseEvent) => {
-          const [mouseX] = d3.pointer(event, interactionLayer.node()!);
+          const [mouseX] = pointer(event, interactionLayer.node()!);
           const x0 = xScale.invert(mouseX);
           const index = bisect(data, x0, 1);
           const d0 = data[index - 1];

--- a/src/components/graph/Scatterplot/AxisBottom.tsx
+++ b/src/components/graph/Scatterplot/AxisBottom.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { ScaleLinear } from "d3";
+import { ScaleLinear } from "d3-scale";
 import { convertNumberNotation } from "@/utils/notation";
 
 type AxisBottomProps = {

--- a/src/components/graph/Scatterplot/AxisLeft.tsx
+++ b/src/components/graph/Scatterplot/AxisLeft.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import { ScaleLinear } from "d3";
+import { ScaleLinear } from "d3-scale";
 import { convertNumberNotation } from "@/utils/notation";
 
 type AxisLeftProps = {

--- a/src/components/graph/Scatterplot/Scatterplot.tsx
+++ b/src/components/graph/Scatterplot/Scatterplot.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
-import * as d3 from 'd3';
+import { scaleLinear, select, axisBottom, axisLeft } from "d3";
 import { Schema, NumberSchema, DataType, Value } from "@/schema";
 import { Filter, filterMatrix } from "@/utils/filters";
 import { transformOps, TransformType } from "@/utils/transform";
@@ -196,7 +196,7 @@ export const Scatterplot = ({
     setFilters((prevFilters) => prevFilters.filter((_, i) => i !== index));
   };
 
-  const svg = d3.select(scatterRef.current!);
+  const svg = select(scatterRef.current!);
   const domain = {
     x: [
       transformOps[xTransform]((schema[xAxisIdx] as NumberSchema).range.min),
@@ -207,16 +207,16 @@ export const Scatterplot = ({
       transformOps[yTransform]((schema[yAxisIdx] as NumberSchema).range.max)
     ]
   };
-  const xScale = d3.scaleLinear()
+  const xScale = scaleLinear()
     .domain(domain.x)
     .range([0, boundsWidth]);
 
-  const yScale = d3.scaleLinear()
+  const yScale = scaleLinear()
     .domain(domain.y)
     .range([boundsHeight, 0]);
 
-  const xAxis = d3.axisBottom(xScale);
-  const yAxis = d3.axisLeft(yScale);
+  const xAxis = axisBottom(xScale);
+  const yAxis = axisLeft(yScale);
 
   svg.selectAll('*').remove();
 

--- a/src/components/graph/Scatterplot/Scatterplot.tsx
+++ b/src/components/graph/Scatterplot/Scatterplot.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
-import { scaleLinear, select, axisBottom, axisLeft } from "d3";
+import { scaleLinear } from "d3-scale";
+import { select } from "d3-selection";
+import { axisBottom, axisLeft } from "d3-axis";
 import { Schema, NumberSchema, DataType, Value } from "@/schema";
 import { Filter, filterMatrix } from "@/utils/filters";
 import { transformOps, TransformType } from "@/utils/transform";

--- a/src/components/query/DateTimeRangeSelector/DateTimeRangeSelector.tsx
+++ b/src/components/query/DateTimeRangeSelector/DateTimeRangeSelector.tsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState, useRef } from "react";
 import "./DateTimeRangeSelector.css";
-import _ from "lodash";
 
 interface DateTimeRangeSelectorProps {
   domain: {
@@ -16,7 +15,7 @@ export const DateTimeRangeSelector: React.FC<DateTimeRangeSelectorProps> = ({ do
   const range = useRef<HTMLDivElement>(null);
 
   const getPercent = useCallback(
-    (value: number) => _.round(((value - domain.min) / (domain.max - domain.min)) * 100),
+    (value: number) => Math.round(((value - domain.min) / (domain.max - domain.min)) * 100),
     [domain]
   );
 
@@ -38,7 +37,7 @@ export const DateTimeRangeSelector: React.FC<DateTimeRangeSelectorProps> = ({ do
         max={domain.max}
         value={minVal}
         onChange={event => {
-          const value = _.min([Number(event.target.value), maxVal - 1]) as number;
+          const value = Math.min(Number(event.target.value), maxVal - 1) as number;
           setMinVal(value);
           onChange([new Date(value), new Date(maxVal)]);
         }}
@@ -50,7 +49,7 @@ export const DateTimeRangeSelector: React.FC<DateTimeRangeSelectorProps> = ({ do
         max={domain.max}
         value={maxVal}
         onChange={event => {
-          const value = _.max([Number(event.target.value), minVal + 1]) as number;
+          const value = Math.max(Number(event.target.value), minVal + 1) as number;
           setMaxVal(value);
           onChange([new Date(minVal), new Date(value)]);
         }}

--- a/src/schema/parser.ts
+++ b/src/schema/parser.ts
@@ -1,52 +1,67 @@
 import { DataType, Schema, CategoricalSchema, NumberSchema, DateTimeSchema, Value } from './schema';
 import dayjs from 'dayjs';
-import _ from 'lodash';
+
+function mean(values: number[]): number {
+  if (values.length === 0) return NaN;
+  return values.reduce((sum, val) => sum + val, 0) / values.length;
+}
+
+function countBy<T>(array: T[]): Record<string, number> {
+  return array.reduce((acc, val) => {
+    const key = String(val);
+    acc[key] = (acc[key] || 0) + 1;
+    return acc;
+  }, {} as Record<string, number>);
+}
 
 function isDatetime(values: Value[]): boolean {
-  return values.every((v) => dayjs(v).isValid())
+  return values.every((v) => dayjs(v).isValid());
 }
 
 function isNumerical(values: Value[]): boolean {
-  return !isNaN(_.mean(values))
+  return !isNaN(mean(values as number[]));
 }
 
 export function inferSchema(keys: string[], matrix: Value[][]): Schema[] {
   return keys.map((key: string, index: number) => {
     if (isNumerical(matrix[index])) {
+      const values = matrix[index].filter((v) => v !== null && v !== undefined) as number[];
       return {
         type: DataType.Number,
         rows: matrix[0].length,
         index,
         key,
         range: {
-          min: _.min(matrix[index]),
-          max: _.max(matrix[index]),
+          min: Math.min(...values),
+          max: Math.max(...values),
         },
-        mean: _.mean(matrix[index].filter((v) => v !== null && v !== undefined))
-      } as NumberSchema
+        mean: mean(values)
+      } as NumberSchema;
     }
+
     if (isDatetime(matrix[index])) {
-      const values = matrix[index].map((v) => dayjs(v).unix() * 1000)
+      const values = matrix[index].map((v) => dayjs(v).unix() * 1000);
       return {
         type: DataType.DateTime,
         rows: matrix[0].length,
         index,
         key,
         range: {
-          minUnix: _.min(values.filter((v) => v > 0)),
-          maxUnix: _.max(values.filter((v) => v < dayjs().unix() * 1000)),
-          minDateTime: dayjs(_.min(values.filter((v) => v > 0))).format("YYYY-MM-DD HH:mm:ss"),
-          maxDateTime: dayjs(_.max(values.filter((v) => v < dayjs().unix() * 1000))).format("YYYY-MM-DD HH:mm:ss"),
+          minUnix: Math.min(...values.filter((v) => v > 0)),
+          maxUnix: Math.max(...values.filter((v) => v < dayjs().unix() * 1000)),
+          minDateTime: dayjs(Math.min(...values.filter((v) => v > 0))).format("YYYY-MM-DD HH:mm:ss"),
+          maxDateTime: dayjs(Math.max(...values.filter((v) => v < dayjs().unix() * 1000))).format("YYYY-MM-DD HH:mm:ss"),
         },
-        frequencies: _.countBy(matrix[index].map((v) => (v === null || v === undefined || v === "") ? "N/A" : v))
-      } as DateTimeSchema
+        frequencies: countBy(matrix[index].map((v) => (v === null || v === undefined || v === "") ? "N/A" : v))
+      } as DateTimeSchema;
     }
+
     return {
       type: DataType.Categorical,
       rows: matrix[0].length,
       index,
       key,
-      frequencies: _.countBy(matrix[index].map((v) => (v === null || v === undefined) ? "N/A" : v))
-    } as CategoricalSchema
-  })
+      frequencies: countBy(matrix[index].map((v) => (v === null || v === undefined) ? "N/A" : v))
+    } as CategoricalSchema;
+  });
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,18 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react-swc';
 import path from 'path';
+import { visualizer } from "rollup-plugin-visualizer";
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [
+    react(),
+    visualizer({
+      open: true,
+      filename: "bundle-report.html",
+      gzipSize: true,
+      brotliSize: true,
+    }),
+  ],
   resolve: {
     alias: {
       '@': path.resolve(__dirname, 'src'),


### PR DESCRIPTION
## feat

Adds `rollup-plugin-visualizer` and uses it in the vite build step to generate a report.

This PR reduces the bundle size by removing the lodash dependency and use selective imports for d3.

Bundle size comparison:

```bash
dist/assets/index-DegEU4Mk.js   404.73 kB │ gzip: 136.92 kB
```
is now down to
```
dist/assets/index-CAmn3ZfF.js   313.40 kB │ gzip: 104.46 kB
```
